### PR TITLE
Dungeon-RPG: Extend the dungeon grid with cells

### DIFF
--- a/src/dungeon_rpg/entities/actor.py
+++ b/src/dungeon_rpg/entities/actor.py
@@ -11,10 +11,9 @@ class Actor(Entity):
                  willpower, charisma, damage, id, entity_type, alignment, name):
         super().__init__(strength, dexterity, endurance,
                          intelligence, willpower, charisma,
-                         damage, id)
+                         damage, id,name)
         self.entity_type = entity_type
         self.alignment = alignment
-        self.name = name
 
     def behavior(self, player, dungeon):
         movement_logic = MovementLogic(self, dungeon)

--- a/src/dungeon_rpg/entities/actor_generator.py
+++ b/src/dungeon_rpg/entities/actor_generator.py
@@ -26,12 +26,11 @@ class ActorGenerator:
                 pos_y = random.randint(0, dungeon.height - 1)
                 pos_x = random.randint(0, dungeon.width - 1)
 
-                if dungeon.grid[pos_y][pos_x] is None:
+                cell = dungeon.get_cell(pos_y, pos_x)
+                if not cell.isBlocking:
                     enemy.position_y = pos_y
                     enemy.position_x = pos_x
                     break
-                elif pos_x and pos_y == 0:
-                    continue
             
             dungeon.place_entity(enemy, enemy.position_y, enemy.position_x)
             actors.append(enemy)

--- a/src/dungeon_rpg/entities/entity.py
+++ b/src/dungeon_rpg/entities/entity.py
@@ -5,7 +5,7 @@ class Entity:
     """
     def __init__(self, strength: int, dexterity: int, endurance: int, 
                  intelligence: int, willpower:int, charisma: int, 
-                 damage: int, id: str):
+                 damage: int, id: str, name = ""):
         self.strength = strength
         self.dexterity = dexterity
         self.endurance = endurance
@@ -13,6 +13,7 @@ class Entity:
         self.willpower = willpower
         self.charisma = charisma
         self.id = id
+        self.name = name
 
         self.max_health = self.endurance
         self.health = self.max_health

--- a/src/dungeon_rpg/entities/movement_logic.py
+++ b/src/dungeon_rpg/entities/movement_logic.py
@@ -37,8 +37,7 @@ class MovementLogic:
         logging.debug(f"Entity: {self.entity.name} Y:{self.entity.position_y} X:{self.entity.position_x}")
 
         cell = self.dungeon.get_cell(new_y, new_x)
-
-        if cell:
+        if cell.entity:
             dy, dx = self.get_direction(new_y, new_x)
             direction = self.DIRECTIONS.get((dy, dx), "UNKNOWN") #If not moved there is no direction
             logging.debug(f"Direction result:{direction}")
@@ -52,16 +51,16 @@ class MovementLogic:
                 cell_left = self.dungeon.get_cell(new_y, new_x - 1)
                 cell_right = self.dungeon.get_cell(new_y, new_x + 1)
 
-                if cell_left and cell_right:
+                if cell_left and cell_right and cell_left.entity and cell_right.entity:
                     new_y, new_x = self.step_back(dy, dx)
 
                 if occupied_count_left > occupied_count_right:
-                    if not cell_right:
+                    if cell_right.entity is None:
                         new_x += 1
                     else:
                         new_x -= 1
                 elif occupied_count_left < occupied_count_right:
-                    if not cell_left:
+                    if cell_left.entity is None:
                         new_x -= 1
                     else:
                         new_x += 1
@@ -81,16 +80,16 @@ class MovementLogic:
                 cell_up = self.dungeon.get_cell(new_y - 1, new_x)
                 cell_down = self.dungeon.get_cell(new_y + 1, new_x)
 
-                if cell_up and cell_down:
+                if cell_up and cell_down and cell_up.entity and cell_down.entity:
                     new_y, new_x = self.step_back(dy, dx)
 
                 if occupied_count_up > occupied_count_down:
-                    if not occupied_count_down:
+                    if cell_down.entity is None:
                         new_y -= 1
                     else:
                         new_y += 1 
                 elif occupied_count_up < occupied_count_down:
-                    if not cell_up:
+                    if cell_up.entity is None:
                         new_y += 1  
                     else:
                         new_y -= 1
@@ -104,7 +103,7 @@ class MovementLogic:
               
         message = self.dungeon.move_entity(self.entity, new_y, new_x)
 
-        if not message:
+        if message is None:
             logging.debug(f"Entity moving to: {self.entity.name} Y:{new_y} X:{new_x}")
             self.entity.position_x = new_x
             self.entity.position_y = new_y
@@ -129,9 +128,8 @@ class MovementLogic:
             new_y += dy
             new_x += dx
             cell = self.dungeon.get_cell(new_y, new_x)
-            if cell:
-                if isinstance(cell, Entity):
-                    occupied_count += 1
+            if cell and cell.entity:
+                occupied_count += 1
             else:
                 break
         return occupied_count
@@ -156,8 +154,9 @@ class MovementLogic:
         stepback_y = self.entity.position_y + rdy
         stepback_x = self.entity.position_x + rdx
 
-        if not self.dungeon.get_cell(stepback_y, stepback_x):
-            logging.debug(f"{self.entity.name} steps back to ({stepback_y}, {stepback_x})")
+        cell = self.dungeon.get_cell(stepback_y, stepback_x)
+        if cell and not cell.entity:
+            logging.debug(f"{self.entity.name} steps back...")
             return stepback_y, stepback_x
         else:
             logging.debug("No space to step back, staying in place.")

--- a/src/dungeon_rpg/game_rules/game_controll.py
+++ b/src/dungeon_rpg/game_rules/game_controll.py
@@ -28,6 +28,8 @@ class GameControll:
 
             dungeon = self.dungeon_generator.generate_dungeon()
 
+            dungeon.place_entity(self.player, self.player.position_y, self.player.position_x)
+
             enemies = self.actor_generator.generate_actors(dungeon,
                                              econsts.EntityType.HUMANOID,
                                              econsts.Alignment.HOSTILE,
@@ -35,7 +37,6 @@ class GameControll:
 
             self.player.position_x = 0
             self.player.position_y = 0
-            dungeon.place_entity(self.player, self.player.position_y, self.player.position_x)
             
             show_stats = False
 
@@ -119,9 +120,9 @@ class GameControll:
     def check_neighboors(self, dungeon):
         py, px = self.player.position_y, self.player.position_x
         for dy, dx in mconsts.NEIGHBOR_CELLS:
-            actor = dungeon.get_cell(py + dy, px + dx)
-            if actor:
-                self.evaluate_actor(actor)
+            cell = dungeon.get_cell(py + dy, px + dx)
+            if cell and cell.entity:
+                self.evaluate_actor(cell.entity)
 
     def evaluate_actor(self, actor):
         name = actor.name

--- a/src/dungeon_rpg/map/cell.py
+++ b/src/dungeon_rpg/map/cell.py
@@ -1,0 +1,18 @@
+class DungeonCell:
+    def __init__(self, coord_y, coord_x):
+        self.coordinate_y = coord_y
+        self.coordinate_x = coord_x
+
+        self.entity = None
+        self.items = []
+        self.objects = []
+
+        self.isBlocking = False
+
+    def set_entity(self, entity):
+        self.entity = entity
+        self.isBlocking = True
+
+    def remove_entity(self):
+        self.entity = None
+        self.isBlocking = False

--- a/src/dungeon_rpg/map/dungeon_room.py
+++ b/src/dungeon_rpg/map/dungeon_room.py
@@ -1,3 +1,4 @@
+from dungeon_rpg.map.cell import DungeonCell
 class DungeonRoom:
     """
     Basic 2D list to represent a dungeon room.
@@ -5,53 +6,72 @@ class DungeonRoom:
     def __init__(self, width: int, height: int, size):
         self.width = width
         self.height = height
-        # Empty grid filled with None (no entity)
-        self.grid = [[None for _ in range(width)] for _ in range(height)]
         self.size = size
 
-    def place_entity(self, entity, y: int, x: int):
-        if not(0 <= x < self.width and 0 <= y < self.height):
-            raise ValueError("Position out of bounds")
-        if self.grid[y][x] is not None:
-            raise ValueError("Cell already occupied")
-        self.grid[y][x] = entity
+        self.init_cells()
 
-    def remove_entity(self, entity, y: int, x: int):
-        if self.is_valid_cell(y, x):
-            self.grid[y][x] = None
 
-    def find_entity(self, entity):
-        for y in range(self.height):
-            for x in range(self.width):
-                if self.grid[y][x] is entity:
-                    return (y, x)
-        return None
-    
+    def init_cells(self):
+        self.grid = [
+            [DungeonCell(coord_y, coord_x) for coord_x in range(self.width)]
+            for coord_y in range(self.height)
+            ]
+        
+        
     def get_cell(self, y, x):
         if not self.is_valid_cell(y, x):
             return None
         return self.grid[y][x]
+    
+
+    def place_entity(self, entity, y: int, x: int):
+        cell = self.get_cell(y, x)
+        if not cell:
+            raise ValueError("Position out of bounds")
+        if cell.isBlocking:
+            raise ValueError("Cell already occupied")
+        cell.set_entity(entity)
+
+
+    def remove_entity(self, entity, y: int, x: int):
+        cell = self.get_cell(y, x)
+        if cell and entity == cell.entity:
+            cell.remove_entity()
+
+
+    def find_entity(self, entity):
+        for row in self.grid:
+            for cell in row:
+                if entity == cell.entity:
+                    return (cell.coordinate_y, cell.coordinate_x)
+        return None
+
 
     def move_entity(self, entity, new_y: int, new_x: int):
-        pos = self.find_entity(entity)
-        if pos is None:
-            return "Entity not found in dungeon"
+        old_pos = self.find_entity(entity)
+        if not old_pos:
+            return "Entity not found"
         
-        if not self.is_valid_cell(new_y, new_x):
+        old_y, old_x = old_pos
+        old_cell = self.get_cell(old_y, old_x)
+        new_cell = self.get_cell(new_y, new_x)
+        
+        if not new_cell:
             return "You hit the wall"
-        
-        if self.grid[new_y][new_x] is not None:
+        if new_cell.isBlocking:
             return "Field is already occupied"
 
-        old_y, old_x = pos
-        self.grid[old_y][old_x] = None 
-        self.grid[new_y][new_x] = entity
+        old_cell.remove_entity() 
+        new_cell.set_entity(entity)
+        return None
+
 
     def is_valid_cell(self, y: int, x: int):
         return 0 <= x < self.width and 0 <= y < self.height
 
+
     def __str__(self):
         rows = []
         for row in self.grid:
-            rows.append(" ".join(cell.id if cell else "." for cell in row))
+            rows.append(" ".join(cell.entity.id if cell and cell.entity else "." for cell in row))
         return "\n".join(rows)

--- a/tests/entities/test_entity.py
+++ b/tests/entities/test_entity.py
@@ -3,40 +3,41 @@ from dungeon_rpg.entities import entity
 
 class EntityTest(unittest.TestCase):
     def test_entity_creation(self):
-        entity = entity.Entity(10, 10, 10, 10, 10, 10, 4, "T")
+        ent = entity.Entity(10, 10, 10, 10, 10, 10, 4, "T", "test")
 
          # Base stats
-        self.assertEqual(entity.strength, 10)
-        self.assertEqual(entity.dexterity, 10)
-        self.assertEqual(entity.endurance, 10)
-        self.assertEqual(entity.intelligence, 10)
-        self.assertEqual(entity.willpower, 10)
-        self.assertEqual(entity.charisma, 10)
-        self.assertEqual(entity.id, "T")
+        self.assertEqual(ent.strength, 10)
+        self.assertEqual(ent.dexterity, 10)
+        self.assertEqual(ent.endurance, 10)
+        self.assertEqual(ent.intelligence, 10)
+        self.assertEqual(ent.willpower, 10)
+        self.assertEqual(ent.charisma, 10)
+        self.assertEqual(ent.id, "T")
+        self.assertEqual(ent.name, "test")
 
         # Derived stats
-        self.assertEqual(entity.max_health, 10)
-        self.assertEqual(entity.health, 10)
-        self.assertEqual(entity.max_pain_tolerance, 20)
-        self.assertEqual(entity.pain_tolerance, 20)
-        self.assertEqual(entity.initiative, 20)
-        self.assertEqual(entity.melee_attack, 20)
-        self.assertEqual(entity.melee_defense, 70)
-        self.assertEqual(entity.ranged_attack, 10)
-        self.assertEqual(entity.ranged_defense, 50)
+        self.assertEqual(ent.max_health, 10)
+        self.assertEqual(ent.health, 10)
+        self.assertEqual(ent.max_pain_tolerance, 20)
+        self.assertEqual(ent.pain_tolerance, 20)
+        self.assertEqual(ent.initiative, 20)
+        self.assertEqual(ent.melee_attack, 20)
+        self.assertEqual(ent.melee_defense, 70)
+        self.assertEqual(ent.ranged_attack, 10)
+        self.assertEqual(ent.ranged_defense, 50)
 
     def test_take_damage(self):
-        entity = entity.Entity(5, 5, 5, 5, 5, 5, 2, "T")
+        ent = entity.Entity(5, 5, 5, 5, 5, 5, 2, "T")
 
-        entity.take_damage(1, 5)
-        self.assertEqual(entity.health, 4)
-        self.assertEqual(entity.pain_tolerance, 5)
-        self.assertTrue(entity.is_alive())
+        ent.take_damage(1, 5)
+        self.assertEqual(ent.health, 4)
+        self.assertEqual(ent.pain_tolerance, 5)
+        self.assertTrue(ent.is_alive())
 
-        entity.take_damage(10, 20)
-        self.assertEqual(entity.health, 0)
-        self.assertEqual(entity.pain_tolerance, 0)
-        self.assertFalse(entity.is_alive())
+        ent.take_damage(10, 20)
+        self.assertEqual(ent.health, 0)
+        self.assertEqual(ent.pain_tolerance, 0)
+        self.assertFalse(ent.is_alive())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/game_rules/test_combat.py
+++ b/tests/game_rules/test_combat.py
@@ -7,37 +7,37 @@ from unittest.mock import patch
 class CombatTest(unittest.TestCase):
     def test_successful_attack(self):
         # Melee attack: 36 (18 + 18)
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
         # Melee defense: 70 (60 + 10)
         # Health: 18 Pain Tolerance: 36
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
 
         Combat.melee_attack(attacker, defender, attack_roll=40, damage_roll=4)
         self.assertEqual(defender.health, 18)
         self.assertEqual(defender.pain_tolerance, 32)
 
     def test_failed_attack(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
 
         Combat.melee_attack(attacker, defender, attack_roll=10, damage_roll=4)
         self.assertEqual(defender.health, 18)
         self.assertEqual(defender.pain_tolerance, 36)
 
     def test_fumble_attack(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=1, damage_roll=4)
 
         self.assertIn("Critical failure!", combat_log)
-        self.assertIn("A fumbles the attack!", combat_log)
+        self.assertIn("Attacker fumbles the attack!", combat_log)
         self.assertEqual(defender.health, 18)
         self.assertEqual(defender.pain_tolerance, 36)
 
     def test_critical_attack(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
         defender.melee_defense = 100
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=100, damage_roll=4)
@@ -46,37 +46,37 @@ class CombatTest(unittest.TestCase):
         self.assertEqual(defender.pain_tolerance, 26)
 
     def test_overwhelming_attack(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 5, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 5, 18, 10, 18, 10, 1, "D", "Defender")
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=99, damage_roll=4)
-        self.assertIn("Overwhelming strike! D loses 4 health and 8 pain tolerance.", combat_log)
+        self.assertIn("Overwhelming strike! Defender loses 4 health and 8 pain tolerance.", combat_log)
         self.assertEqual(defender.health, 14)
         self.assertEqual(defender.pain_tolerance, 28)
 
     def test_critical_and_overwhelm(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=100, damage_roll=4)
         self.assertIn("Critical hit!", combat_log)
-        self.assertIn("Overwhelming strike! D loses 7 health and 14 pain tolerance.", combat_log)
+        self.assertIn("Overwhelming strike! Defender loses 7 health and 14 pain tolerance.", combat_log)
         self.assertEqual(defender.health, 11)
         self.assertEqual(defender.pain_tolerance, 22)
 
     def test_low_pain_tolerance(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
         defender.pain_tolerance = 3
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=50, damage_roll=6)
-        self.assertIn("Hit! D loses 3 health and 3 pain tolerance.", combat_log)
+        self.assertIn("Hit! Defender loses 3 health and 3 pain tolerance.", combat_log)
         self.assertEqual(defender.health, 15)
         self.assertEqual(defender.pain_tolerance, 0)
 
     def test_attack_equals_defense(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
         defense = defender.melee_defense
         attack_roll = defense - attacker.melee_attack
 
@@ -86,26 +86,26 @@ class CombatTest(unittest.TestCase):
         self.assertEqual(defender.pain_tolerance, 36)
 
     def test_defender_no_pain_tolerance(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 0, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 0, 1, "D", "Defender")
         defender.pain_tolerance = 0
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=70, damage_roll=5)
-        self.assertIn("Hit! D loses 5 health.", combat_log)
+        self.assertIn("Hit! Defender loses 5 health.", combat_log)
         self.assertEqual(defender.health, 13)
         self.assertEqual(defender.pain_tolerance, 0)
 
     def test_collateral_damage(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
 
         combat_log = Combat.melee_attack(attacker, defender, attack_roll=60, damage_roll=10)
         self.assertIn("Collateral damage: 2", combat_log)
         self.assertEqual(defender.health, 16)
 
     def test_defender_death(self):
-        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A")
-        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D")
+        attacker = entity.Entity(18, 18, 10, 10, 10, 10, 5, "A", "Attacker")
+        defender = entity.Entity(10, 10, 18, 10, 18, 10, 1, "D", "Defender")
 
         Combat.melee_attack(attacker, defender, attack_roll=95, damage_roll=20)
         self.assertEqual(defender.health, 0)

--- a/tests/map/test_dungeon.py
+++ b/tests/map/test_dungeon.py
@@ -1,35 +1,80 @@
 import unittest
 from dungeon_rpg.map import dungeon_room
 from dungeon_rpg.entities import entity
+import dungeon_rpg.map.constants as mconsts
 
 class DungeonTest(unittest.TestCase):
+    def setUp(self):
+        self.dun = dungeon_room.DungeonRoom(3, 3, mconsts.RoomSize.SMALL)
+        self.ent = entity.Entity(5, 5, 5, 5, 5, 5, 2, "T")
+
     def test_dungeon_size(self):
-        dun = dungeon_room.Dungeon(10, 8)
+        self.assertEqual(3, len(self.dun.grid))
+        self.assertEqual(3, len(self.dun.grid[0]))
+        self.assertEqual(mconsts.RoomSize.SMALL, self.dun.size)
 
-        self.assertEqual(8, len(dun.grid))
-        self.assertEqual(10, len(dun.grid[0]))
-
-    def test_entity_placement(self):
-        dun = dungeon_room.Dungeon(3, 3)
-        entity = entity.Entity(5, 5, 5, 5, 5, 5, 2, "T")
-        dun.place_entity(entity, 2, 2)
-        self.assertEqual(dun.grid[2][2], entity)
-
-    def test_entity_find(self):
-        dun = dungeon_room.Dungeon(3, 3)
-        entity = entity.Entity(5, 5, 5, 5, 5, 5, 2, "T")
-        dun.place_entity(entity, 1, 2)
-        y, x = dun.find_entity(entity)
-        self.assertEqual(y, 1)
-        self.assertEqual(x, 2)
-
+    def test_place_entity_in_cell(self):
+        self.dun.place_entity(self.ent, 1, 1)
+        cell = self.dun.get_cell(1, 1)
+        self.assertEqual(cell.entity, self.ent)
+        self.assertTrue(cell.isBlocking)
+    
     def test_bounds(self):
-        dun = dungeon_room.Dungeon(3, 3)
-        entity = entity.Entity(5, 5, 5, 5, 5, 5, 2, "T")
         with self.assertRaises(ValueError):
-            dun.place_entity(entity, 4, 1)
+            self.dun.place_entity(self.ent, 4, 1)
         with self.assertRaises(ValueError):
-            dun.place_entity(entity, -2, 1)
+            self.dun.place_entity(self.ent, -2, 1)
+
+    def test_occupied_cell(self):
+        self.dun.place_entity(self.ent, 1, 1)
+        another = entity.Entity(5, 5, 5, 5, 5, 5, 2, "X")
+        with self.assertRaises(ValueError):
+            self.dun.place_entity(another, 1, 1)
+
+    def test_remove_entity_from_cell(self):
+        self.dun.place_entity(self.ent, 0, 0)
+        self.dun.remove_entity(self.ent, 0, 0)
+        cell = self.dun.get_cell(0, 0)
+        self.assertIsNone(cell.entity)
+        self.assertFalse(cell.isBlocking)
+
+    def test_remove_wrong_entity_does_nothing(self):
+        self.dun.place_entity(self.ent, 1, 1)
+        another = entity.Entity(1, 1, 1, 1, 1, 1, 1, "X")
+        self.dun.remove_entity(another, 1, 1)
+        self.assertEqual(self.dun.get_cell(1, 1).entity, self.ent)
+
+    def test_move_entity_success(self):
+        self.dun.place_entity(self.ent, 0, 0)
+        result = self.dun.move_entity(self.ent, 1, 1)
+        self.assertIsNone(result)
+        self.assertIsNone(self.dun.get_cell(0, 0).entity)
+        self.assertEqual(self.dun.get_cell(1, 1).entity, self.ent)
+
+    def test_move_entity_into_wall(self):
+        self.dun.place_entity(self.ent, 2, 2)
+        result = self.dun.move_entity(self.ent, 3, 3)
+        self.assertEqual(result, "You hit the wall")
+
+    def test_move_entity_into_occupied_cell(self):
+        self.dun.place_entity(self.ent, 0, 0)
+        blocker = entity.Entity(1, 1, 1, 1, 1, 1, 1, "B")
+        self.dun.place_entity(blocker, 1, 0)
+        result = self.dun.move_entity(self.ent, 1, 0)
+        self.assertEqual(result, "Field is already occupied")
+
+    def test_move_nonexistent_entity(self):
+        result = self.dun.move_entity(self.ent, 1, 1)
+        self.assertEqual(result, "Entity not found")
+
+    def test_find_entity(self):
+        self.dun.place_entity(self.ent, 2, 2)
+        pos = self.dun.find_entity(self.ent)
+        self.assertEqual(pos, (2, 2))
+
+    def test_find_nonexistent_entity(self):
+        pos = self.dun.find_entity(self.ent)
+        self.assertIsNone(pos)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
	Added Cells to the dungeon grid so that a position
	defined with coordinates x and y now can be extended
	with complex behavior. Store items, object etc.
        Added and modified unit tests, fixed movement logic
        to match the new cell based code